### PR TITLE
adding jenkins setup instructions

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,0 +1,22 @@
+FROM jenkins/jenkins:2.222.3
+
+USER root
+
+# Install the latest Docker CE binaries and add user `jenkins` to the docker group
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install apt-transport-https \
+      ca-certificates \
+      curl \
+      gnupg2 \
+      software-properties-common && \
+    curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg > /tmp/dkey; apt-key add /tmp/dkey && \
+    add-apt-repository \
+      "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+      $(lsb_release -cs) \
+      stable" && \
+   apt-get update && \
+   apt-get -y --no-install-recommends install docker-ce && \
+   apt-get clean && \
+   usermod -aG docker jenkins
+
+USER jenkins

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,0 +1,72 @@
+# Jenkins Setup
+
+## Jenkins Build
+
+To allow for the Jenkins container to use Docker-container based builds, we need build a new Docker image first:
+
+```js
+docker build -t apigee/jenkins .
+```
+
+## Run Jenkins with a mounted home folder
+
+Although the volume mount for the jenkins_home directory is optional, it is highly encouraged to avoid having to do the manual jenkins configuration multiple times. 
+
+```sh
+sudo mkdir /var/jenkins_home
+sudo chmod 777 /var/jenkins_home
+
+docker run -d -it -p 8080:8080 -p 50000:50000 --name jenkins \
+    -v /var/jenkins_home:/var/jenkins_home \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    --restart unless-stopped \
+    apigee/jenkins:latest
+```
+
+## Manual Jenkins Init
+
+1. Once the Jenkins UI has loaded and prompts you for the admin key, supply the inital admin key which you can obtain from running `docker exec jenkins cat /var/jenkins_home/secrets/initialAdminPassword`
+1. Click the button to install the default plugins
+1. Create an admin user with the username `admin` (Password and Email can be arbitrary)
+1. Navigate to `localhost:8080/me/configure`, create an API token, and store it in an `JENKINS_KEY` variable: `export JENKINS_KEY=<key goes here>`
+
+
+### Install the reporting plugins
+
+```sh
+curl -u admin:$JENKINS_KEY -X POST -d '<jenkins><install plugin="htmlpublisher@1.22" /></jenkins>' --header 'Content-Type: text/xml' "http://localhost:8080/pluginManager/installNecessaryPlugins"
+curl -u admin:$JENKINS_KEY -X POST -d '<jenkins><install plugin="cucumber-reports@5.0.2" /></jenkins>' --header 'Content-Type: text/xml' "http://localhost:8080/pluginManager/installNecessaryPlugins"
+```
+
+## Setup Jenkins Credentials
+
+This assumes you have the environment variables `APIGEE_USERNAME` and `APIGEE_PASSWORD` populated with your Apigee credentials.
+
+```sh
+curl -X POST \
+    -u admin:$JENKINS_KEY \
+    -H 'content-type:application/xml' \
+    -d "
+<com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>
+  <scope>GLOBAL</scope>
+  <id>apigee</id>
+  <description>Apigee CICD Credentials</description>
+  <username>$APIGEE_USERNAME</username>
+  <password>$APIGEE_PASSWORD</password>
+</com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>
+" "http://localhost:8080/credentials/store/system/domain/_/createCredentials"
+```
+
+## Create a Multibrach Jenkins Job
+
+Use the UI to configure the Jenkins Job for multibranch pipelines:
+
+1. Point to the SCM Jenkinsfile
+1. Set the Git repo accordingly
+1. Set the build trigger / polling frequency
+
+The `config.xml` contains a readily configured pipeline which may or may not be applicable given the detached versioning of the jenkins plugins:
+
+```sh
+curl -X POST -u admin:$JENKINS_KEY --header "Content-Type: application/xml" -d '@config.xml' http://localhost:8080/createItem?name=CurrencyAPI
+```

--- a/jenkins/config.xml
+++ b/jenkins/config.xml
@@ -1,0 +1,50 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject plugin="workflow-multibranch@2.21">
+  <actions/>
+  <description></description>
+  <properties>
+    <org.jenkinsci.plugins.docker.workflow.declarative.FolderConfig plugin="docker-workflow@1.23">
+      <dockerLabel></dockerLabel>
+      <registry plugin="docker-commons@1.16"/>
+    </org.jenkinsci.plugins.docker.workflow.declarative.FolderConfig>
+  </properties>
+  <folderViews class="jenkins.branch.MultiBranchProjectViewHolder" plugin="branch-api@2.5.6">
+    <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.."/>
+  </folderViews>
+  <healthMetrics>
+    <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric plugin="cloudbees-folder@6.12">
+      <nonRecursive>false</nonRecursive>
+    </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+  </healthMetrics>
+  <icon class="jenkins.branch.MetadataActionFolderIcon" plugin="branch-api@2.5.6">
+    <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.."/>
+  </icon>
+  <orphanedItemStrategy class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy" plugin="cloudbees-folder@6.12">
+    <pruneDeadBranches>true</pruneDeadBranches>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>-1</numToKeep>
+  </orphanedItemStrategy>
+  <triggers/>
+  <disabled>false</disabled>
+  <sources class="jenkins.branch.MultiBranchProject$BranchSourceList" plugin="branch-api@2.5.6">
+    <data>
+      <jenkins.branch.BranchSource>
+        <source class="jenkins.plugins.git.GitSCMSource" plugin="git@4.2.2">
+          <remote>https://github.com/danistrebel/apigee-ci-cd.git</remote>
+          <credentialsId></credentialsId>
+          <traits>
+            <jenkins.plugins.git.traits.BranchDiscoveryTrait/>
+          </traits>
+        </source>
+        <strategy class="jenkins.branch.DefaultBranchPropertyStrategy">
+          <properties class="empty-list"/>
+        </strategy>
+      </jenkins.branch.BranchSource>
+    </data>
+    <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.."/>
+  </sources>
+  <factory class="org.jenkinsci.plugins.workflow.multibranch.WorkflowBranchProjectFactory">
+    <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.."/>
+    <scriptPath>Jenkinsfile</scriptPath>
+  </factory>
+</org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject>


### PR DESCRIPTION
This PR contains instructions and scripts on how to set up a suitable Jenkins docker container to be used with this demo.

Most important things to consider:
* Minimal Dockerfile to extend the standard image with DockerCE
* Using docker in docker to use the daemon on the docker host to run the docker based Jenkins agents
* Creating credentials and adding plugins though the Jenkins API
* Multibranch Pipeline Job to simplify setup 